### PR TITLE
Replace theta.T to theta

### DIFF
--- a/Exercise2/exercise2.ipynb
+++ b/Exercise2/exercise2.ipynb
@@ -422,7 +422,7 @@
     "    grad = np.zeros(theta.shape)\n",
     "\n",
     "    # ====================== YOUR CODE HERE ======================\n",
-    "    h = sigmoid(X.dot(theta.T))\n",
+    "    h = sigmoid(X.dot(theta))\n",
     "    \n",
     "    J = (1 / m) * np.sum(-y.dot(np.log(h)) - (1 - y).dot(np.log(1 - h)))\n",
     "    grad = (1 / m) * (h - y).dot(X)\n",


### PR DESCRIPTION
In costFunction(theta, X, y) we don't need to transpose the array theta. In fact ,the implementation with theta.T in the sigmoid function works because in this case theta.T = theta . You can test it by print(theta , theta.T) which prints [0. 0. 0.] [0. 0. 0.]. In case we cas see the true transposition of theta with print(theta , theta[:, None]) which prints [0. 0. 0.]
 [[0.]
 [0.]
 [0.]]. In this case the code would't run , so theta should not be transposed.